### PR TITLE
Use botkit to send the welcome message

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,20 @@
+{
+  env: {
+    node: true,
+    es6: true,
+  },
+  extends: eslint:recommended,
+  parserOptions: {
+    ecmaVersion: 8,
+  },
+  rules: {
+    comma-dangle: [2, only-multiline],
+    comma-spacing: 2,
+    indent: [2, 2], # two-space indentation
+    no-console: off,
+    prefer-const: 2,
+    quotes: [2, single, {avoidEscape: true}],
+    semi: 2, # require semi-colons
+    strict: [2, global]
+  }
+}

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node index.js
+worker: npm start

--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
-A bot that welcomes new users to the UCTech team on Slack.
+A bot that hangs out in the UC Tech Slack team and helps with common tasks
 
-## Installation
+## Running Locally:
 
-Clone this project. 
-
-Then, [create a bot user integration](https://my.slack.com/services/new/bot).
-Take note of the generated API token.
-
-Now, install all dependencies.
-
+1. Install node and npm
+2. `git clone uctechbot`
+3. `npm install`
+4. add a `.env` file with:
 ```bash
-npm install
+SLACK_API_TOKEN="TOKEN"
 ```
+5. Run uctechbot with `npm start`
+5. test uctechbot with `npm test`
 
-Finally, run this application whilst passing the API token to it.
 
-```bash
-# Replace xxx-xxx-xxxxx with the bot's API token.
-SLACK_API_TOKEN=xxx-xxx-xxxxx node index.js
-```
-
-## Deployment 
-
-[How to deploy your Slack Bot to Heroku.](https://blog.heroku.com/how-to-deploy-your-slack-bots-to-heroku)
+## Deploying to heroku
+1. Install the heroku CLI (`brew install heroku`)
+2. `heroku create`
+3. `git push heroku master`
+4. `heroku config:set SLACK_API_TOKEN="TOKEN"`

--- a/index.js
+++ b/index.js
@@ -1,55 +1,15 @@
-var fs = require('fs');
-var express = require('express')();
-var http = require('http').Server(express);
-var RtmClient = require('@slack/client').RtmClient;
-var WebClient = require('@slack/client').WebClient;
-var RTM_EVENTS = require('@slack/client').RTM_EVENTS;
-var bodyParser = require('body-parser');
+'use strict';
+require('dotenv').config();
 
+const bot = require('./lib/bot.js');
 
-var token = process.env.SLACK_API_TOKEN || '';
-var welcome = fs.readFileSync('welcome.txt', 'utf8');
-var rtm = new RtmClient(token);
-var web = new WebClient(token);
+// seperate skills into individual functions
+const welcome = require('./skills/welcome.js');
+const uptime = require('./skills/uptime.js');
 
-rtm.start();
+// consolidate ways for the bot to be mentioned
+const mention = ['direct_message', 'direct_mention', 'mention'];
 
-rtm.on(RTM_EVENTS.TEAM_JOIN, function(message) {
-  var user = message.user;
-  console.log('User ' + user.name + ' joined the team.');
-  web.im.open(user.id, function(err, res) {
-    if (err) {
-      console.error('An error occurred while opening a direct message channel to user ' + user.name + '. Error: ' + err);
-      return;
-    }
-    if (res.ok) {
-      rtm.sendMessage(welcome, res.channel.id);
-    } else {
-      console.error('Failed to open a direct message channel to user ' + user.name + '. Error message: ' + res.error);
-    }
-  });
-});
-
-
-// register middleware
-express.use(bodyParser.json());
-express.use(bodyParser.urlencoded({ extended: true }));
-
-// serve up something at the default route so Heroku won't crash
-express.set('port', process.env.PORT || 5000);
-express.get('/', function(req, res) {
-  res.send("42");
-});
-
-// custom command endpoint. prints out the welcome message.
-express.post('/welcome-message', function (req, res) {
-  if (req.body.token === process.env.SLACK_WELCOMEMESSAGE_COMMAND_TOKEN) {
-    res.send(welcome);
-    return;
-  }
-  res.status(403).send('Access Denied.');
-});
-
-express.listen(express.get('port'), function() {
-  console.log('App is running on port', express.get('port'));
-});
+// define when each skill is called
+bot.on('team_join', welcome);
+bot.hears(['uptime', 'identify yourself', 'who are you', 'what is your name'], mention, uptime);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -1,0 +1,15 @@
+'use strict';
+if (!process.env.SLACK_API_TOKEN) {
+  throw new Error('Error: Specify SLACK_TOKEN in environment');
+}
+
+const Botkit = require('botkit');
+const controller = Botkit.slackbot({
+  debug: false,
+  require_delivery: true,
+});
+controller.spawn({
+  token: process.env.SLACK_API_TOKEN
+}).startRTM();
+
+module.exports = controller;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A bot that welcomes new users to the UCTech team on Slack.",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
@@ -18,9 +19,11 @@
   "author": "Stefan Topfstedt",
   "license": "MIT",
   "dependencies": {
-    "@slack/client": "3.5.4",
-    "body-parser": "1.15.2",
-    "express": "4.14.0",
-    "foreman": "1.4.1"
+    "app-root-path": "^2.0.1",
+    "botkit": "^0.5.6",
+    "dotenv": "^4.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.1.0"
   }
 }

--- a/skills/uptime.js
+++ b/skills/uptime.js
@@ -1,0 +1,36 @@
+'use strict';
+/*
+  Sends information about the server and uptime (useful for debugging)
+
+  Many thanks to https://github.com/howdyai/botkit/blob/master/slack_bot.js
+  Where most of this was stolen from
+*/
+
+const os = require('os');
+
+const uptime = (bot, message) => {
+  const formatUptime = function(uptime) {
+    var unit = 'second';
+    if (uptime > 60) {
+      uptime = uptime / 60;
+      unit = 'minute';
+    }
+    if (uptime > 60) {
+      uptime = uptime / 60;
+      unit = 'hour';
+    }
+    if (uptime != 1) {
+      unit = unit + 's';
+    }
+
+    uptime = uptime + ' ' + unit;
+    return uptime;
+  };
+  const hostname = os.hostname();
+  const uptime = formatUptime(process.uptime());
+  const reponse = ':robot_face: I am a bot named <@' + bot.identity.name +
+          '>. I have been running for ' + uptime + ' on ' + hostname + '.';
+  bot.reply(message, reponse);
+};
+
+module.exports = uptime;

--- a/skills/welcome.js
+++ b/skills/welcome.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/*
+  Welcomes new users to the team by sending them a private message containing
+  the contents of /welcome.txt
+*/
+
+const fs = require('fs');
+
+const welcome = (bot, message) => {
+  bot.startPrivateConversation({user: message.user.id}, function(err, convo) {
+    const appRoot = require('app-root-path');
+    const welcome = fs.readFileSync(`${appRoot}/welcome.txt`, 'utf8');
+    convo.say(welcome);
+  });
+};
+
+module.exports = welcome;


### PR DESCRIPTION
Reorganization to use botkit to handle the messaging.

This gives us some room to grow and add new functionality in an organized way. It does me we should change the name of the bot when it joins the team to something more generic than greeterbot.

This removes the webapp code - which I think was just a POST response endpoint, but I'm not 100% sure. 