### PR TITLE
chore: bump axios to 0.21.0 where we can

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "@azure/ms-rest-js": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.15.tgz",
-      "integrity": "sha512-kIB71V3DcrA4iysBbOsYcxd4WWlOE7OFtCUYNfflPODM0lbIR23A236QeTn5iAeYwcHmMjR/TAKp5KQQh/WqoQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.9.1.tgz",
+      "integrity": "sha512-F1crHKhmsvFLM9fsnDyCGFd2E2KR9GEZm5oBVV5D5k2EBQ7u7idtSJlSF6RDLDIrGWtc4NnFdYwsoiW8NLlBQg==",
       "requires": {
         "@types/tunnel": "0.0.0",
-        "axios": "^0.19.0",
+        "axios": "^0.21.1",
         "form-data": "^2.3.2",
         "tough-cookie": "^2.4.3",
         "tslib": "^1.9.2",
@@ -157,26 +157,40 @@
       }
     },
     "@slack/types": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.9.0.tgz",
-      "integrity": "sha512-RmwgMWqOtzd2JPXdiaD/tyrDD0vtjjRDFdxN1I3tAxwBbg4aryzDUVqFc8na16A+3Xik/UN8X1hvVTw8J4EB9w=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.10.0.tgz",
+      "integrity": "sha512-tA7GG7Tj479vojfV3AoxbckalA48aK6giGjNtgH6ihpLwTyHE3fIgRrvt8TWfLwW8X8dyu7vgmAsGLRG7hWWOg=="
     },
     "@slack/web-api": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.12.0.tgz",
-      "integrity": "sha512-ygSnNHVid7PltGo7W36f2SNVHyliemkzxn9uSwgnWNF7CHmWBKWAylU/eoDml9l5K7akMOxbousiurOw4XqOFg==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.15.0.tgz",
+      "integrity": "sha512-tjQ8Zqv/Fmj9SOL9yIEd7IpTiKfKHi9DKAkfRVeotoX0clMr3SqQtBqO+KZMX27gm7dmgJsQaDKlILyzdCO+IA==",
       "requires": {
         "@slack/logger": ">=1.0.0 <3.0.0",
         "@slack/types": "^1.7.0",
         "@types/is-stream": "^1.1.0",
         "@types/node": ">=8.9.0",
-        "@types/p-queue": "^2.3.2",
-        "axios": "^0.19.0",
+        "axios": "^0.21.1",
         "eventemitter3": "^3.1.0",
         "form-data": "^2.5.0",
         "is-stream": "^1.1.0",
-        "p-queue": "^2.4.2",
+        "p-queue": "^6.6.1",
         "p-retry": "^4.0.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+          "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
+        }
       }
     },
     "@types/bson": {
@@ -216,11 +230,6 @@
       "version": "14.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.9.tgz",
       "integrity": "sha512-iXuiZ65PL5c8VAlF426GVJGKcsnAb2rW2037LJe3G6eM6nz35bK9QAUOH3Ic3kF4ZcKLpM02sFkSzCflIpoIKA=="
-    },
-    "@types/p-queue": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
-      "integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
     },
     "@types/retry": {
       "version": "0.12.0",
@@ -412,20 +421,20 @@
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
       }
     },
     "axios-mock-adapter": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.18.2.tgz",
-      "integrity": "sha512-e5aTsPy2Viov22zNpFTlid76W1Scz82pXeEwwCXdtO85LROhHAF8pHF2qDhiyMONLxKyY3lQ+S4UCsKgrlx8Hw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz",
+      "integrity": "sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
         "is-buffer": "^2.0.3"
       }
     },
@@ -501,25 +510,83 @@
       }
     },
     "botbuilder": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.10.4.tgz",
-      "integrity": "sha512-tEtxebCvSs173fSpbKJovExUhlXJBNOJwUieeW9Mx5OO6WXeczslonvivtynuQAeyAO5qzLCgOF6HGyMohXMNw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.11.1.tgz",
+      "integrity": "sha512-6VtAtJzkAuuBXz2TwPT49yNeLkhpjfGouys24qPNZSBdl5UWkhniKo1t3DdIU8wPjlyGfqxmW8DQfUmfGI9elQ==",
       "requires": {
-        "@azure/ms-rest-js": "1.8.15",
+        "@azure/ms-rest-js": "1.9.1",
         "@types/node": "^10.17.27",
-        "axios": "^0.19.0",
-        "botbuilder-core": "4.10.4",
-        "botframework-connector": "4.10.4",
-        "botframework-streaming": "4.10.4",
+        "axios": "^0.21.1",
+        "botbuilder-core": "4.11.1",
+        "botframework-connector": "4.11.1",
+        "botframework-streaming": "4.11.1",
         "filenamify": "^4.1.0",
         "fs-extra": "^7.0.1",
         "moment-timezone": "^0.5.28"
       },
       "dependencies": {
+        "@azure/ms-rest-js": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.9.1.tgz",
+          "integrity": "sha512-F1crHKhmsvFLM9fsnDyCGFd2E2KR9GEZm5oBVV5D5k2EBQ7u7idtSJlSF6RDLDIrGWtc4NnFdYwsoiW8NLlBQg==",
+          "requires": {
+            "@types/tunnel": "0.0.0",
+            "axios": "^0.21.1",
+            "form-data": "^2.3.2",
+            "tough-cookie": "^2.4.3",
+            "tslib": "^1.9.2",
+            "tunnel": "0.0.6",
+            "uuid": "^3.2.1",
+            "xml2js": "^0.4.19"
+          }
+        },
         "@types/node": {
-          "version": "10.17.40",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.40.tgz",
-          "integrity": "sha512-3hZT2z2/531A5pc8hYhn1gU5Qb1SIRSgMLQ6zuHA5xtt16lWAxUGprtr8lJuc9zNJMXEIIBWfSnzqBP/4mglpA=="
+          "version": "10.17.51",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
+          "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+        },
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "botbuilder-core": {
+          "version": "4.11.1",
+          "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.11.1.tgz",
+          "integrity": "sha512-Vtv2cUSXjVHZ3x081KFbqb/CpWfU24k2x89AAgsLWbTUytNW0QTRNgByjdznNl4CqV3b98mI6qJsk/fqFGnq4w==",
+          "requires": {
+            "assert": "^1.4.1",
+            "botframework-connector": "4.11.1",
+            "botframework-schema": "4.11.1"
+          }
+        },
+        "botframework-connector": {
+          "version": "4.11.1",
+          "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.11.1.tgz",
+          "integrity": "sha512-oaQHGoF35kjTgczUM8MhJu9A4PWuUYVSvM6w0KKvVRL0You9ivHa0FT1JrUodxzLCY0ZWNVWdYijstXEq8feSQ==",
+          "requires": {
+            "@azure/ms-rest-js": "1.9.1",
+            "@types/jsonwebtoken": "7.2.8",
+            "adal-node": "0.2.1",
+            "base64url": "^3.0.0",
+            "botframework-schema": "4.11.1",
+            "cross-fetch": "^3.0.5",
+            "jsonwebtoken": "8.0.1",
+            "rsa-pem-from-mod-exp": "^0.8.4"
+          }
+        },
+        "botframework-schema": {
+          "version": "4.11.1",
+          "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.11.1.tgz",
+          "integrity": "sha512-RDDEuh1yHnCqVppUIOh6pv51OQ7mN7wTPiBSvhIjhLW6zSJxDn7ho9QbJl1KJRnpQj4qnNvh1ZlrqTiL9QBIjA=="
+        },
+        "follow-redirects": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+          "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
         }
       }
     },
@@ -576,26 +643,24 @@
       }
     },
     "botframework-connector": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.10.4.tgz",
-      "integrity": "sha512-TsoAi5S8Jfpg+nxDswgoEiw2lG9ZRTexxGtOplcxwt7GdI19vuUP+v2mZdWtsc68vzzl/BRcBQh6NaIJmBkZ0Q==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.11.1.tgz",
+      "integrity": "sha512-oaQHGoF35kjTgczUM8MhJu9A4PWuUYVSvM6w0KKvVRL0You9ivHa0FT1JrUodxzLCY0ZWNVWdYijstXEq8feSQ==",
       "requires": {
-        "@azure/ms-rest-js": "1.8.15",
+        "@azure/ms-rest-js": "1.9.1",
         "@types/jsonwebtoken": "7.2.8",
-        "@types/node": "^10.17.27",
         "adal-node": "0.2.1",
         "base64url": "^3.0.0",
-        "botframework-schema": "4.10.4",
-        "form-data": "^2.3.3",
+        "botframework-schema": "4.11.1",
+        "cross-fetch": "^3.0.5",
         "jsonwebtoken": "8.0.1",
-        "node-fetch": "^2.6.0",
         "rsa-pem-from-mod-exp": "^0.8.4"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.40",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.40.tgz",
-          "integrity": "sha512-3hZT2z2/531A5pc8hYhn1gU5Qb1SIRSgMLQ6zuHA5xtt16lWAxUGprtr8lJuc9zNJMXEIIBWfSnzqBP/4mglpA=="
+        "botframework-schema": {
+          "version": "4.11.1",
+          "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.11.1.tgz",
+          "integrity": "sha512-RDDEuh1yHnCqVppUIOh6pv51OQ7mN7wTPiBSvhIjhLW6zSJxDn7ho9QbJl1KJRnpQj4qnNvh1ZlrqTiL9QBIjA=="
         }
       }
     },
@@ -605,9 +670,9 @@
       "integrity": "sha512-xkbCC+BrDhfA+rPITp3dmI+YY8pqBRO4cGQhjWcmwrKp+bIsBJU8N5++u/UpSMY94KXJXjTHyYuMEE3xDYBMDg=="
     },
     "botframework-streaming": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.10.4.tgz",
-      "integrity": "sha512-Z5N1YnO6hQMeg4DFOn7wYlYe5C8a14aQ+UiZMklap9/1Yu5izucmWPVXF65qCOG5ua8WDH/mPZyw0NKkvgcRXA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.11.1.tgz",
+      "integrity": "sha512-XZHQrsClzLzIIqWiv1FOrZri7vW21+xfIgrl4pueLmXZT8YM2FytW2EwnAyYIgooEk1CYbLZ/wmmgjxClLSATA==",
       "requires": {
         "@types/ws": "^6.0.3",
         "uuid": "^3.4.0",
@@ -632,45 +697,81 @@
       }
     },
     "botkit-mock": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/botkit-mock/-/botkit-mock-4.10.0.tgz",
-      "integrity": "sha512-eQUfn4GwopIDYzWFmi5svXBEQFJje+xM07696tCZZDtnd8KBfEr1X3FO289JiA9n9ccTExQujq3v+a1O1pU4/Q==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/botkit-mock/-/botkit-mock-4.11.0.tgz",
+      "integrity": "sha512-bc2etI2tNwYq4HrWDYqKfBLR7evaN+3TFmftAgvvqo/42eVG2G3pqp1JoHa9EQPUp743vIQLZt3R6wSXfX6zIg==",
       "dev": true,
       "requires": {
-        "axios": "^0.20.0",
+        "axios": "^0.21.0",
         "axios-mock-adapter": "^1.18.1",
-        "botbuilder": "4.10.1",
+        "botbuilder": "4.11.0",
         "botbuilder-adapter-slack": "1.0.13",
         "botkit": "4.10.0"
       },
       "dependencies": {
+        "@azure/ms-rest-js": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.9.0.tgz",
+          "integrity": "sha512-cB4Z2Mg7eBmet1rfbf0QSO1XbhfknRW7B+mX3IHJq0KGHaGJvCPoVTgdsJdCkazEMK1jtANFNEDDzSQacxyzbA==",
+          "dev": true,
+          "requires": {
+            "@types/tunnel": "0.0.0",
+            "axios": "^0.19.0",
+            "form-data": "^2.3.2",
+            "tough-cookie": "^2.4.3",
+            "tslib": "^1.9.2",
+            "tunnel": "0.0.6",
+            "uuid": "^3.2.1",
+            "xml2js": "^0.4.19"
+          },
+          "dependencies": {
+            "axios": {
+              "version": "0.19.2",
+              "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+              "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+              "dev": true,
+              "requires": {
+                "follow-redirects": "1.5.10"
+              }
+            },
+            "follow-redirects": {
+              "version": "1.5.10",
+              "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+              "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+              "dev": true,
+              "requires": {
+                "debug": "=3.1.0"
+              }
+            }
+          }
+        },
         "@types/node": {
-          "version": "10.17.40",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.40.tgz",
-          "integrity": "sha512-3hZT2z2/531A5pc8hYhn1gU5Qb1SIRSgMLQ6zuHA5xtt16lWAxUGprtr8lJuc9zNJMXEIIBWfSnzqBP/4mglpA==",
+          "version": "10.17.51",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
+          "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg==",
           "dev": true
         },
         "axios": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-          "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
           "dev": true,
           "requires": {
             "follow-redirects": "^1.10.0"
           }
         },
         "botbuilder": {
-          "version": "4.10.1",
-          "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.10.1.tgz",
-          "integrity": "sha512-sXWTFXFjGYZ+aCG26Z3Er+xnhqD1nqhXbFGBwH/InlAUB77ucGYXEhffZgxvAcXAy0eHb+L1qLty6T7C0XaTvg==",
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.11.0.tgz",
+          "integrity": "sha512-amNKc8f9M5lGlWn3e3QTYcNFJhGAC+fWU2wV/PQG6Tn7TRBh4tMcxw3tS6WZbgPDHj1KSSe+/Ih4LOLYfYJHTQ==",
           "dev": true,
           "requires": {
-            "@azure/ms-rest-js": "1.8.15",
+            "@azure/ms-rest-js": "1.9.0",
             "@types/node": "^10.17.27",
             "axios": "^0.19.0",
-            "botbuilder-core": "4.10.1",
-            "botframework-connector": "4.10.1",
-            "botframework-streaming": "4.10.1",
+            "botbuilder-core": "4.11.0",
+            "botframework-connector": "4.11.0",
+            "botframework-streaming": "4.11.0",
             "filenamify": "^4.1.0",
             "fs-extra": "^7.0.1",
             "moment-timezone": "^0.5.28"
@@ -697,43 +798,42 @@
           }
         },
         "botbuilder-core": {
-          "version": "4.10.1",
-          "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.10.1.tgz",
-          "integrity": "sha512-eP8h6aK+299kM3fD/n0k7JjPRCfctWGsHRaHdvbvShHODQ4FT0f5E+SM0oaeK/rqlzABMbvImSGKB0FRZNV6kw==",
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.11.0.tgz",
+          "integrity": "sha512-fKFCNsbNG8ISWUG0r63VDwmjOOjgt6TBqB6nmMb9BVVhMMhhosB0wWZCjvrzFqrUuHwaZkeEEaoJLpCRK0Etww==",
           "dev": true,
           "requires": {
             "assert": "^1.4.1",
-            "botframework-schema": "4.10.1"
+            "botframework-connector": "4.11.0",
+            "botframework-schema": "4.11.0"
           }
         },
         "botframework-connector": {
-          "version": "4.10.1",
-          "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.10.1.tgz",
-          "integrity": "sha512-ukQL+OobATL9Uad8aHnwK850mgxy5yANkZtXDSP3f++BphzYb3QahDSZ4wg26yNub0xnTuwKC0sOpYaRpTkwKw==",
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.11.0.tgz",
+          "integrity": "sha512-8Hopo/FZwMwmI5vIFwWKzHxO0pKCWN5c/ggMF3pdSqbsl2B3YcaxKBWdmwbDzIksxSGu6dV0Z91JapD/LJdgeQ==",
           "dev": true,
           "requires": {
-            "@azure/ms-rest-js": "1.8.15",
+            "@azure/ms-rest-js": "1.9.0",
             "@types/jsonwebtoken": "7.2.8",
-            "@types/node": "^10.17.27",
             "adal-node": "0.2.1",
             "base64url": "^3.0.0",
-            "botframework-schema": "4.10.1",
-            "form-data": "^2.3.3",
+            "botframework-schema": "4.11.0",
+            "cross-fetch": "^3.0.5",
             "jsonwebtoken": "8.0.1",
-            "node-fetch": "^2.6.0",
             "rsa-pem-from-mod-exp": "^0.8.4"
           }
         },
         "botframework-schema": {
-          "version": "4.10.1",
-          "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.10.1.tgz",
-          "integrity": "sha512-+7+xAxlO40GxEb+ek5yYW6o6+b3c+OXCYFFbQFUCj9dJwOkFDE0cRXbJCZfT6XbmjnhDSbVM3OsJ/4nttNYXDw==",
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.11.0.tgz",
+          "integrity": "sha512-K/VQ66jFTws2UmJRP3nlKMi4ZQM1xS8yGhh+lA0MoLrYJBgpzCoi9P2isbAub9QQotzQnTv5bK8NiJTwcdt+hQ==",
           "dev": true
         },
         "botframework-streaming": {
-          "version": "4.10.1",
-          "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.10.1.tgz",
-          "integrity": "sha512-6/PZZ8K5UoxZlMa64wzLLZMxMAkEA3vPpSyhu+Oz/VYbuSWsKWagIgml+QkIiYo79BfFmoFya0GP7qjFelAerg==",
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.11.0.tgz",
+          "integrity": "sha512-sJjC01TwMbJKx3yUN0J4AAzwggQ3+G096Kb0/oF3TmxwqibPWcNFH0feHmg5FpWVJn7q5tuZ8vnkKtdfsVnh/g==",
           "dev": true,
           "requires": {
             "@types/ws": "^6.0.3",
@@ -751,9 +851,9 @@
           }
         },
         "follow-redirects": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-          "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+          "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
           "dev": true
         }
       }
@@ -992,6 +1092,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -1608,22 +1716,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2486,6 +2581,11 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-limit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
@@ -2505,17 +2605,36 @@
       }
     },
     "p-queue": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
-      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        }
+      }
     },
     "p-retry": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-      "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+      "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
       "requires": {
         "@types/retry": "^0.12.0",
         "retry": "^0.12.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dotenv": "^8.2.0"
   },
   "devDependencies": {
-    "botkit-mock": "^4.10.0",
+    "botkit-mock": "^4.11.0",
     "eslint": "^7.11.0",
     "eslint-plugin-mocha": "^8.0.0",
     "mocha": "^8.1.3"


### PR DESCRIPTION
botkit-mock pins the version of botbuilder it depends on, so we'll ahve
to wait for a new version of botkit-mock before we get a vulnerable
version of axios entirely out of the codebase. But this is still worth
landing, I think, because it gets it out of the actual code for the app.
The vulnerable version is used only in the test mock with this change.